### PR TITLE
CARD-1608 can't add insured item specs to product in IBO, screen flickers

### DIFF
--- a/js/iframeResizer.contentWindow.js
+++ b/js/iframeResizer.contentWindow.js
@@ -818,17 +818,17 @@
         return getTaggedElements('bottom','data-iframe-height');
       },
 
-      maxAll: function getMaxAllHeight(){
-				var currentHeight = Math.max.apply(null,getAllMeasurements(getHeight));
-				var leHeight = Math.max(getHeight.bodyOffset(), getMaxElement('bottom',getAllElements()));
-				if(currentHeight > leHeight) {
-					window.setTimeout(function(){
-						currentHeight = Math.max(getHeight.bodyOffset(),getHeight.bodyScroll(),getHeight.documentElementOffset(), getMaxElement('bottom',getAllElements()));
-						sendMsg(currentHeight,getWidth[widthCalcMode](),null);
-					},100);
-				}
-				return currentHeight;
-			}
+      maxAll: function getMaxAllHeight() {
+        var currentHeight = Math.max.apply(null, getAllMeasurements(getHeight));
+        var leHeight = Math.max(getHeight.bodyOffset(), getMaxElement('bottom', getAllElements()));
+        if (currentHeight > leHeight) {
+          window.setTimeout(function () {
+            currentHeight = Math.max(getHeight.bodyOffset(), getHeight.bodyScroll(), getHeight.documentElementOffset(), getMaxElement('bottom', getAllElements()));
+            sendMsg(currentHeight, getWidth[widthCalcMode](), null);
+          }, 100);
+        }
+        return currentHeight;
+      }
     },
 
     getWidth = {

--- a/js/iframeResizer.contentWindow.js
+++ b/js/iframeResizer.contentWindow.js
@@ -816,7 +816,19 @@
 
       taggedElement: function getTaggedElementsHeight() {
         return getTaggedElements('bottom','data-iframe-height');
-      }
+      },
+
+      maxAll: function getMaxAllHeight(){
+				var currentHeight = Math.max.apply(null,getAllMeasurements(getHeight));
+				var leHeight = Math.max(getHeight.bodyOffset(), getMaxElement('bottom',getAllElements()));
+				if(currentHeight > leHeight) {
+					window.setTimeout(function(){
+						currentHeight = Math.max(getHeight.bodyOffset(),getHeight.bodyScroll(),getHeight.documentElementOffset(), getMaxElement('bottom',getAllElements()));
+						sendMsg(currentHeight,getWidth[widthCalcMode](),null);
+					},100);
+				}
+				return currentHeight;
+			}
     },
 
     getWidth = {


### PR DESCRIPTION
CARD-1608
can't add insured item specs to product in IBO, screen flickers

Description: The new update on chrome 65 and above makes the iframeLC hidden as tab changes which makes the iframeresize to calculate the height impossible as the LC is hidden, so added a timeout to fix that with the logic where it will happen only on the tab change and only when downsizing on iframe LC.